### PR TITLE
attempts to fix nuget.org publish

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,4 @@ deploy:
   artifact: /piggy-.*\.(zip|tar\.gz)/
   tag: v$(appveyor_build_version)
   on:
-    branch: /^(main|dev)$/
+    branch: main

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: qFvoUBcJYV2z0Q8x38cjFDdSdpPclcynF5/FcZbNmSDfQhqTy87D5vBZIp3HaO0I
+    secure: cBbEvLgdPd79AN36d7qbBo0h9Td5kdluiF+TYnmvY+Ldhm3GMGNAtFTR5F1PRuox
   skip_symbols: true
   on:
     branch: /^(main|dev)$/


### PR DESCRIPTION
1. Updates the encrypted NuGet.org deployment API key.
2. Removes "dev" deployment of packages to GitHub, as we don't currently (and don't want to) deploy prerelease packages to GitHub.