### PR TITLE
Fix dotnet tool publishing

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -86,6 +86,10 @@ if ($suffix) {
 }
 if($LASTEXITCODE -ne 0) { exit 11 }
 
+# Stale artifacts cause problems, we change the output type but MSBuild doesn't notice.
+& dotnet clean $project
+if($LASTEXITCODE -ne 0) { exit 11 }
+
 Write-Output "build: Packing executable into dotnet tool Datalust.Piggy.Cli.*.nupkg"
 if ($suffix) {
 	& dotnet pack $project -c Release -o $PSScriptRoot/$artifacts /p:PackAsTool=True --version-suffix=$suffix


### PR DESCRIPTION
```
> piggy version
Unhandled exception. System.MissingMethodException: Entry point not found in assembly 'piggy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null'.
```